### PR TITLE
Refactor single file into basic module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: double-quote-string-fixer
+    -   id: end-of-file-fixer
+    -   id: fix-encoding-pragma
+    -   id: mixed-line-ending
+    -   id: trailing-whitespace
+        exclude: >-
+            (?x)^(
+                tests/.*.*out|
+                tests/.*.in$
+            )$
+
+-   repo: https://github.com/ikamensh/flynt/
+    rev: '0.55'
+    hooks:
+    -   id: flynt
+        args: [
+            '--line-length=120',
+            '--fail-on-change',
+        ]
+
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: 5.0.2
+    hooks:
+    -   id: pydocstyle
+        exclude: &exclude_files >
+            (?x)^(
+                docs/.*|
+                tests/.*(?<!\.py)$
+            )$
+        args: ['--ignore=D104,D202,D203,D213']
+
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.30.0
+    hooks:
+    -   id: yapf
+        name: yapf
+        types: [python]
+        args: ['-i']
+        exclude: 'docs/source/conf.py'
+
+-   repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.6.0
+    hooks:
+    -   id: pylint
+        language: system
+        exclude: *exclude_files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
                 docs/.*|
                 tests/.*(?<!\.py)$
             )$
-        args: ['--ignore=D104,D202,D203,D213']
+        args: ['--ignore=D104,D202,D203,D213,D401']
 
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.30.0

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,8 @@
+[style]
+based_on_style = google
+align_closing_bracket_with_visual_indent = true
+coalesce_brackets = true
+column_limit = 120
+dedent_closing_brackets = true
+indent_dictionary_value = false
+split_arguments_when_comma_terminated = true

--- a/aiida_submission_controller/__init__.py
+++ b/aiida_submission_controller/__init__.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 """A prototype package with tools to submit processes in batches, avoiding to submit too many.
 
 Author: Giovanni Pizzi (2021).
 """
+__version__ = '0.1.0'
 
-# from . import submission_controller
+from .base import BaseSubmissionController
 
-# __all__ = (submission_controller.__all__, )
+__all__ = ('BaseSubmissionController',)

--- a/aiida_submission_controller/__init__.py
+++ b/aiida_submission_controller/__init__.py
@@ -1,0 +1,8 @@
+"""A prototype package with tools to submit processes in batches, avoiding to submit too many.
+
+Author: Giovanni Pizzi (2021).
+"""
+
+# from . import submission_controller
+
+# __all__ = (submission_controller.__all__, )

--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A prototype class to submit processes in batches, avoiding to submit too many.
 
 Author: Giovanni Pizzi (2021).
@@ -6,24 +7,21 @@ import abc
 
 from aiida import engine, orm
 
-__all__ = ('BaseSubmissionController', )
-
 
 class BaseSubmissionController:
     """Controller to submit a maximum number of processes (workflows or calculations) at a given time.
-    
+
     This is an abstract base class: you need to subclass it and define the abstract methods.
     """
 
     def __init__(self, group_label, max_concurrent):
-        """
-        Create a new controller to manage (and limit) concurrent submissions.
+        """Create a new controller to manage (and limit) concurrent submissions.
 
         :param group_label: a group label: the group will be created at instantiation (if not existing already,
             and it will be used to manage the calculations)
         :param extra_unique_keys: a tuple or list of keys of extras that are used to uniquely identify
             a process in the group. E.g. ('value1', 'value2').
-        
+
         :note: try to use actual values that allow for an equality comparison (strings, bools, integers), and avoid
            floats, because of truncation errors.
         """
@@ -80,7 +78,7 @@ class BaseSubmissionController:
 
     def get_all_submitted_pks(self):
         """Return a dictionary of all processes that have been already submitted (i.e., are in the group).
-        
+
         :return: a dictionary where:
 
             - the keys are the tuples with the values of extras that uniquely identifies processes, in the same
@@ -101,7 +99,7 @@ class BaseSubmissionController:
 
     def get_all_submitted_processes(self, only_active=False):
         """Return a dictionary of all processes that have been already submitted (i.e., are in the group).
-        
+
         :return: a dictionary where:
 
             - the keys are the tuples with the values of extras that uniquely identifies processes, in the same
@@ -142,8 +140,7 @@ class BaseSubmissionController:
     @property
     def num_to_run(self):
         """Number of processes that still have to be submitted."""
-        return len(self.get_all_extras_to_submit().difference(
-            self._check_submitted_extras()))
+        return len(self.get_all_extras_to_submit().difference(self._check_submitted_extras()))
 
     @property
     def num_already_run(self):
@@ -151,15 +148,13 @@ class BaseSubmissionController:
         return len(self._check_submitted_extras())
 
     def submit_new_batch(self, dry_run=False, sort=True):
-        """Submit a new batch of calculations, avoiding to have more than self.max_concurrent active at the same time."""
+        """Submit a new batch of calculations, ensuring less than self.max_concurrent active at the same time."""
         to_submit = []
-        extras_to_run = set(self.get_all_extras_to_submit()).difference(
-            self._check_submitted_extras())
+        extras_to_run = set(self.get_all_extras_to_submit()).difference(self._check_submitted_extras())
         if sort:
             extras_to_run = sorted(extras_to_run)
         for workchain_extras in extras_to_run:
-            if len(to_submit) + self._count_active_in_group(
-            ) >= self.max_concurrent:
+            if len(to_submit) + self._count_active_in_group() >= self.max_concurrent:
                 break
             to_submit.append(workchain_extras)
 
@@ -169,17 +164,12 @@ class BaseSubmissionController:
         submitted = {}
         for workchain_extras in to_submit:
             # Get the inputs and the process calculation for submission
-            inputs, process_class = self.get_inputs_and_processclass_from_extras(
-                workchain_extras)
+            inputs, process_class = self.get_inputs_and_processclass_from_extras(workchain_extras)
 
             # Actually submit
             res = engine.submit(process_class, **inputs)
             # Add extras, and put in group
-            res.set_extra_many({
-                key: value
-                for key, value in zip(self.get_extra_unique_keys(),
-                                      workchain_extras)
-            })
+            res.set_extra_many({key: value for key, value in zip(self.get_extra_unique_keys(), workchain_extras)})
             self.group.add_nodes([res])
             submitted[workchain_extras] = res
 
@@ -188,29 +178,28 @@ class BaseSubmissionController:
     @abc.abstractmethod
     def get_extra_unique_keys(self):
         """Return a tuple of the kes of the unique extras that will be used to uniquely identify your workchains."""
-        pass
+        return
 
     @abc.abstractmethod
     def get_all_extras_to_submit(self):
-        """
-        Return a *set* of the values of all extras uniquely identifying all simulations that you want to submit.
-        
+        """Return a *set* of the values of all extras uniquely identifying all simulations that you want to submit.
+
         Each entry of the set must be a tuple, in same order as the keys returned by get_extra_unique_keys().
 
         :note: for each item, pass extra values as tuples (because lists are not hashable, so you cannot make
             a set out of them).
         """
-        pass
+        return
 
     @abc.abstractmethod
     def get_inputs_and_processclass_from_extras(self, extras_values):
         """Return the inputs and the process class for the process to run, associated a given tuple of extras values.
-        
+
         :param extras_values: a tuple of values of the extras, in same order as the keys returned by
             get_extra_unique_keys().
-        
+
         :return: ``(inputs, process_class)``, that will be used as follows:
-           
+
            submit(process_class, **inputs)
         """
-        pass
+        return

--- a/aiida_submission_controller/submission_controller.py
+++ b/aiida_submission_controller/submission_controller.py
@@ -2,14 +2,19 @@
 
 Author: Giovanni Pizzi (2021).
 """
-from aiida import orm, engine, plugins
 import abc
+
+from aiida import engine, orm
+
+__all__ = ('BaseSubmissionController', )
+
 
 class BaseSubmissionController:
     """Controller to submit a maximum number of processes (workflows or calculations) at a given time.
     
     This is an abstract base class: you need to subclass it and define the abstract methods.
     """
+
     def __init__(self, group_label, max_concurrent):
         """
         Create a new controller to manage (and limit) concurrent submissions.
@@ -137,7 +142,8 @@ class BaseSubmissionController:
     @property
     def num_to_run(self):
         """Number of processes that still have to be submitted."""
-        return len(self.get_all_extras_to_submit().difference(self._check_submitted_extras()))
+        return len(self.get_all_extras_to_submit().difference(
+            self._check_submitted_extras()))
 
     @property
     def num_already_run(self):
@@ -146,15 +152,16 @@ class BaseSubmissionController:
 
     def submit_new_batch(self, dry_run=False, sort=True):
         """Submit a new batch of calculations, avoiding to have more than self.max_concurrent active at the same time."""
-
         to_submit = []
-        extras_to_run = set(self.get_all_extras_to_submit()).difference(self._check_submitted_extras())
+        extras_to_run = set(self.get_all_extras_to_submit()).difference(
+            self._check_submitted_extras())
         if sort:
             extras_to_run = sorted(extras_to_run)
         for workchain_extras in extras_to_run:
-            to_submit.append(workchain_extras)
-            if len(to_submit) + self._count_active_in_group() >= self.max_concurrent:
+            if len(to_submit) + self._count_active_in_group(
+            ) >= self.max_concurrent:
                 break
+            to_submit.append(workchain_extras)
 
         if dry_run:
             return {key: None for key in to_submit}
@@ -162,12 +169,17 @@ class BaseSubmissionController:
         submitted = {}
         for workchain_extras in to_submit:
             # Get the inputs and the process calculation for submission
-            inputs, process_class = self.get_inputs_and_processclass_from_extras(workchain_extras)
+            inputs, process_class = self.get_inputs_and_processclass_from_extras(
+                workchain_extras)
 
             # Actually submit
-            res = engine.submit(process_class, **inputs)            
+            res = engine.submit(process_class, **inputs)
             # Add extras, and put in group
-            res.set_extra_many({key: value for key, value in zip(self.get_extra_unique_keys(), workchain_extras)})
+            res.set_extra_many({
+                key: value
+                for key, value in zip(self.get_extra_unique_keys(),
+                                      workchain_extras)
+            })
             self.group.add_nodes([res])
             submitted[workchain_extras] = res
 
@@ -202,121 +214,3 @@ class BaseSubmissionController:
            submit(process_class, **inputs)
         """
         pass
-
-
-class AdditionTableSubmissionController(BaseSubmissionController):
-    """The implementation of a SubmissionController to compute a 12x12 table of additions."""
-
-    def __init__(self, code_name, *args, **kwargs):
-        """Pass also a code name, that should be a code associated to an `arithmetic.add` plugin."""
-        super().__init__(*args, **kwargs)
-        self._code = orm.load_code(code_name)
-        self._process_class = plugins.CalculationFactory('arithmetic.add')
-
-    def get_extra_unique_keys(self):
-        """Return a tuple of the kes of the unique extras that will be used to uniquely identify your workchains.
-
-        Here I will use the value of the two integer operands as unique identifiers.
-        """
-        return ['left_operand', 'right_operand']
-
-    def get_all_extras_to_submit(self):
-        """
-        I want to compute a 12x12 table.
-
-        I will return therefore the following list of tuples: [(1, 1), (1, 2), ..., (12, 12)].
-        """
-        all_extras = set()
-        for left_operand in range(1, 13):
-            for right_operand in range(1, 13):
-                all_extras.add((left_operand, right_operand))
-        return all_extras
-
-    def get_inputs_and_processclass_from_extras(self, extras_values):
-        """Return inputs and process class for the submission of this specific process.
-
-        I just submit an ArithmeticAdd calculation summing the two values stored in the extras:
-        ``left_operand + right_operand``.
-        """
-        inputs = {'code': self._code, 'x': orm.Int(extras_values[0]), 'y': orm.Int(extras_values[1])}
-        return inputs, self._process_class
-
-
-if __name__ == "__main__":
-    import sys
-
-    ## IMPORTANT: make sure that you have a `add@localhost` code, that you can setup (once you have a
-    ## localhost computer) using the following command, for instance:
-    ##
-    ##    verdi code setup -L add --on-computer --computer=localhost -P arithmetic.add --remote-abs-path=/bin/bash -n
-
-    # Create a controller
-    controller = AdditionTableSubmissionController(
-        code_name = 'add@localhost',
-        group_label = 'tests/addition_table',
-        max_concurrent = 10
-    )
-
-    print("Max concurrent :", controller.max_concurrent)
-    print("Active slots   :", controller.num_active_slots)
-    print("Available slots:", controller.num_available_slots)
-    print("Already run    :", controller.num_already_run)
-    print("Still to run   :", controller.num_to_run)
-    print()
-
-    ## Uncomment the following two lines if you just want to do a dry-run without actually submitting anything
-    #print("I would run next:")
-    #print(controller.submit_new_batch(dry_run=True))
-    
-    print("Let's run a new batch!")
-    # Note: the number might differ from controller.num_available_slots shown above, as some more
-    # calculations might be over in the meantime.
-    run_processes = controller.submit_new_batch(dry_run=False)
-    for run_process_extras, run_process in run_processes.items():
-        print(f"{run_process_extras} --> PK = {run_process.pk}")
-
-    print()
-
-    ## Print results
-    print(">>> RESULTS UP TO NOW:")
-    print("    Legend:")
-    print("      ###: not yet submitted")
-    print("      ???: submitted, but no results (not finished or failed)")
-    all_submitted = controller.get_all_submitted_processes()
-    sys.stdout.write('   |')
-    for right in range(1, 13):
-        sys.stdout.write(f'{right:3d} ')
-    sys.stdout.write('\n')
-    sys.stdout.write('----' + '----' * 12)
-    sys.stdout.write('\n')
-
-    # Get all results in a single query
-    qb = controller.get_query(process_projections=controller.get_process_extra_projections())
-    qb.append(orm.Int, project='attributes.value', with_incoming='process')
-    results = {}
-    for res in qb.all():
-        ## TODO: see if there is a way to make this even simpler
-        results[tuple(res[:len(controller.get_process_extra_projections())])] = res[len(controller.get_process_extra_projections()):]
-
-    # I get all running ones - the query above will not distinguish between processes that do not exist at all
-    # (never submitted) and those that exist but do not have an output (failed, or still running)
-    all_submitted = controller.get_all_submitted_processes()
-
-    # Print table
-    for left in range(1, 13):
-        sys.stdout.write(f'{left:2d} |')
-        for right in range(1, 13):
-            # One could do process.outputs.sum.value, but this will perform a query every time,
-            # so the loop becomes much slower
-            result = results.get((left, right), None)
-            if result is None:
-                # This could be both because it was never submitted, or because it's running or failed.
-                # I try to distinguish the two (I still don't distinguish between failed or running)
-                if (left, right) in all_submitted:
-                    sys.stdout.write('??? ')
-                else:
-                    sys.stdout.write('### ')
-            else:
-                # result is a list of projected values, here there's only one
-                sys.stdout.write(f'{result[0]:3d} ')
-        sys.stdout.write('\n')

--- a/examples/add.py
+++ b/examples/add.py
@@ -1,0 +1,105 @@
+"""An example of a SubmissionController implementation to compute a 12x12 table of additions."""
+
+from aiida import orm, plugins
+from aiida_submission_controller import BaseSubmissionController
+
+
+class AdditionTableSubmissionController(BaseSubmissionController):
+    """The implementation of a SubmissionController to compute a 12x12 table of additions."""
+
+    def __init__(self, code_name, *args, **kwargs):
+        """Pass also a code name, that should be a code associated to an `arithmetic.add` plugin."""
+        super().__init__(*args, **kwargs)
+        self._code = orm.load_code(code_name)
+        self._process_class = plugins.CalculationFactory('arithmetic.add')
+
+    def get_extra_unique_keys(self):
+        """Return a tuple of the keys of the unique extras that will be used to uniquely identify your workchains.
+
+        Here I will use the value of the two integer operands as unique identifiers.
+        """
+        return ['left_operand', 'right_operand']
+
+    def get_all_extras_to_submit(self):
+        """
+        I want to compute a 12x12 table.
+
+        I will return therefore the following list of tuples: [(1, 1), (1, 2), ..., (12, 12)].
+        """
+        all_extras = set()
+        for left_operand in range(1, 13):
+            for right_operand in range(1, 13):
+                all_extras.add((left_operand, right_operand))
+        return all_extras
+
+    def get_inputs_and_processclass_from_extras(self, extras_values):
+        """Return inputs and process class for the submission of this specific process.
+
+        I just submit an ArithmeticAdd calculation summing the two values stored in the extras:
+        ``left_operand + right_operand``.
+        """
+        inputs = {'code': self._code, 'x': orm.Int(extras_values[0]), 'y': orm.Int(extras_values[1])}
+        return inputs, self._process_class
+
+
+if __name__ == "__main__":
+    import sys
+
+    ## IMPORTANT: make sure that you have a `add@localhost` code, that you can setup (once you have a
+    ## localhost computer) using the following command, for instance:
+    ##
+    ##    verdi code setup -L add --on-computer --computer=localhost -P arithmetic.add --remote-abs-path=/bin/bash -n
+    # Create a controller
+    controller = AdditionTableSubmissionController(
+        code_name = 'add@localhost',
+        group_label = 'tests/addition_table',
+        max_concurrent = 10
+    )
+
+    print("Max concurrent :", controller.max_concurrent)
+    print("Active slots   :", controller.num_active_slots)
+    print("Available slots:", controller.num_available_slots)
+    print("Already run    :", controller.num_already_run)
+    print("Still to run   :", controller.num_to_run)
+    print()
+
+    ## Uncomment the following two lines if you just want to do a dry-run without actually submitting anything
+    #print("I would run next:")
+    #print(controller.submit_new_batch(dry_run=True))
+    
+    print("Let's run a new batch!")
+    # Note: the number might differ from controller.num_available_slots shown above, as some more
+    # calculations might be over in the meantime.
+    run_processes = controller.submit_new_batch(dry_run=False)
+    for run_process_extras, run_process in run_processes.items():
+        print(f"{run_process_extras} --> PK = {run_process.pk}")
+
+    print()
+
+    ## Print results
+    print(">>> RESULTS UP TO NOW:")
+    print("    Legend:")
+    print("      ###: not yet submitted")
+    print("      ???: submitted, but no results (not finished or failed)")
+    all_submitted = controller.get_all_submitted_processes()
+    sys.stdout.write('   |')
+    for right in range(1, 13):
+        sys.stdout.write(f'{right:3d} ')
+    sys.stdout.write('\n')
+    sys.stdout.write('----' + '----' * 12)
+    sys.stdout.write('\n')
+
+    # Print table
+    for left in range(1, 13):
+        sys.stdout.write(f'{left:2d} |')
+        for right in range(1, 13):
+            process = all_submitted.get((left, right))
+            if process is None:
+                result = '###' # No node
+            else:
+                try:
+                    result = f'{process.outputs.sum.value:3d}'
+                except AttributeError:
+                    result = f'???'  # Probably not completed, does not have output 'sum'
+            sys.stdout.write(result + ' ')
+        sys.stdout.write('\n')

--- a/examples/pw_base.py
+++ b/examples/pw_base.py
@@ -1,0 +1,162 @@
+"""An example of a SubmissionController implementation for a small set of PwBaseWorkChains."""
+
+import typing as ty
+
+from aiida import orm, plugins, load_profile
+from aiida_submission_controller.submission_controller import BaseSubmissionController
+from qe_tools import CONSTANTS
+import warnings
+
+
+class PwBaseSubmissionController(BaseSubmissionController):
+    """The implementation of a SubmissionController to run a small set of PwBaseWorkChains."""
+
+    INPUT_PLUGIN = 'quantumespresso.pw'
+    WORKFLOW_ENTRY_POINT = 'quantumespresso.pw.base'
+
+    def __init__(
+            self,
+            code_id: ty.Union[str, int],
+            structure_group_id: ty.Union[str, int],
+            structure_filters: ty.Dict[str, ty.Any],
+            pseudo_family_id: ty.Union[str, int],
+            *args,
+            **kwargs
+        ):
+        """Add a `code_id` argument for loading a code associated to `quantumespresso.pw`."""
+        super().__init__(*args, **kwargs)
+        self._code = orm.load_code(identifier=code_id)
+        self._process_class = plugins.WorkflowFactory(self.WORKFLOW_ENTRY_POINT)
+        self._structure_group = orm.load_group(identifier=structure_group_id)
+        self._structure_filters = structure_filters
+        self._pseudo_family = orm.load_group(identifier=pseudo_family_id)
+
+        # assert self._code.get_plugin_name() == self.INPUT_PLUGIN
+
+    def get_extra_unique_keys(self) -> ty.Tuple[str]:
+        """Return a tuple of the extra key or keys used to uniquely identify your workchains."""
+        return ('mpid',)
+
+    def get_all_extras_to_submit(self) -> ty.Set[ty.Tuple[str]]:
+        """Return a set of all the unique extras to submit."""
+        pseudo_family_elements = set(self._pseudo_family.elements)
+        
+        qb = orm.QueryBuilder()
+        qb.append(orm.Group, filters={'label': self._structure_group.label}, tag='group')
+        qb.append(orm.StructureData,
+                  project=['extras.mpid', 'attributes.kinds'],
+                  tag='structure',
+                  with_group='group',
+                  filters={
+                      'extras': {'has_key': 'mpid'},
+                      **self._structure_filters
+                  }
+            )
+        qr = qb.all()
+
+        all_extras = []
+        for (mpid, kinds) in qr:
+            kind_names = set(kind['name'] for kind in kinds)
+            if kind_names.issubset(pseudo_family_elements):
+                all_extras.append((mpid,))
+        all_extras = set(all_extras)
+        
+        # all_extras = set((mpid,) for mpid in qb.all(flat=True))
+        return all_extras
+
+    def _get_structure_from_extras(self, extras_values: ty.Tuple[str]) -> orm.StructureData:
+        qb = orm.QueryBuilder()
+        qb.append(orm.Group, filters={'label': self._structure_group.label}, tag='group')
+        qb.append(orm.StructureData,
+                  project='*',
+                  tag='structure',
+                  with_group='group',
+                  filters={
+                      'extras.mpid': extras_values[0]
+                  }
+            )
+        structure = qb.all(flat=True)[0]
+        return structure
+
+    def get_inputs_and_processclass_from_extras(self, extras_values: ty.Tuple[str]):
+        """Construct the inputs and get the process class from the values of the uniquely identifying extras."""
+        structure = self._get_structure_from_extras(extras_values)
+        try:
+            pseudos = self._pseudo_family.get_pseudos(structure=structure)
+            ecutwfc, ecutrho = self._pseudo_family.get_recommended_cutoffs(structure=structure)
+
+            inputs = {
+                'kpoints_distance': orm.Float(0.15),
+                'pw': {
+                    'metadata': {
+                        'options': {
+                            'resources': {
+                                'num_machines': 1,
+                                'num_mpiprocs_per_machine': 1
+                            },
+                            'max_wallclock_seconds': 30 * 60,
+                            'withmpi': True
+                        }
+                    },
+                    'code': self._code,
+                    'structure': structure,
+                    'pseudos': pseudos,
+                    'parameters': orm.Dict(dict={
+                        'CONTROL': {
+                            'calculation': 'scf',
+                        },
+                        'SYSTEM': {
+                            'ecutwfc': ecutwfc,
+                            'ecutrho': ecutrho,
+                            'nosym': False,
+                            'smearing': 'gaussian',
+                            'degauss': 0.2 / CONSTANTS.ry_to_ev
+                        },
+                        'ELECTRONS': {
+                            'conv_thr': 1e-10,
+                            'mixing_beta': 4e-1,
+                            'electron_maxstep': 0,
+                            'scf_must_converge': False
+                        }
+                    })
+                },
+            }
+
+            return inputs, self._process_class
+
+        except ValueError:
+            warnings.warn(f'Cannot run mpid {extras_values[0]} for lack of pseudos.')
+            return None, None
+
+
+if __name__ == '__main__':
+    # import sys
+
+    load_profile('qnscf')
+
+    controller = PwBaseSubmissionController(
+        code_id='pw-6.7_qnscf',
+        structure_group_id='mp_all',
+        structure_filters={
+            'attributes.sites': {
+                'longer': 0,
+                'shorter': 2
+            }
+        },
+        pseudo_family_id='SSSP/1.1/PBE/efficiency',
+        group_label='tests/mp_all/pw_pdos_qnscf',
+        max_concurrent=100
+    )
+
+    print("Max concurrent :", controller.max_concurrent)
+    print("Active slots   :", controller.num_active_slots)
+    print("Available slots:", controller.num_available_slots)
+    print("Already run    :", controller.num_already_run)
+    print("Still to run   :", controller.num_to_run)
+    print()
+
+    run_processes = controller.submit_new_batch(dry_run=False)
+    for run_process_extras, run_process in run_processes.items():
+        print(f'{run_process_extras} --> <{run_process}>')
+
+    print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,6 @@ good-names = [
     "j",
     "k",
     "pk",
-    "qb"
+    "qb",
+    "qr"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.messages_control]
+disable = [
+    "bad-continuation",
+    "bad-option-value",
+    "cyclic-import",
+    "duplicate-code",
+    "import-outside-toplevel",
+    "inconsistent-return-statements",
+    "locally-disabled",
+    "no-else-raise",
+    "too-few-public-methods",
+    "too-many-ancestors",
+    "too-many-arguments",
+    "too-many-instance-attributes",
+    "useless-suppression",
+    "unnecessary-comprehension"
+]
+
+[tool.pylint.basic]
+good-names = [
+    "_",
+    "x",
+    "y",
+    "z",
+    "i",
+    "j",
+    "k",
+    "pk",
+    "qb"
+]

--- a/setup.json
+++ b/setup.json
@@ -1,0 +1,19 @@
+{
+    "author": "Giovanni Pizzi",
+    "classifiers": [
+        "Development Status :: 4 - Beta",
+        "Framework :: AiiDA",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
+    ],
+    "description": "Utilities for controlling submission flow in AiiDA",
+    "python_requires": ">=3.6",
+    "license": "MIT License",
+    "name": "aiida-submission-controller",
+    "version": "0.1.0"
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Define the setup for `aiida-submission-controller`."""
+
+
+def setup_package():
+    """Install the `aiida-submission-controller` package."""
+    import json
+    from setuptools import setup, find_packages
+
+    filename_setup_json = 'setup.json'
+    filename_description = 'README.md'
+
+    with open(filename_setup_json, 'r') as handle:
+        setup_json = json.load(handle)
+
+    with open(filename_description, 'r') as handle:
+        description = handle.read()
+
+    setup(
+        include_package_data=True,
+        packages=find_packages(),
+        long_description=description,
+        long_description_content_type='text/markdown',
+        **setup_json
+    )
+
+
+if __name__ == '__main__':
+    setup_package()


### PR DESCRIPTION
Here, I've refactored the `submission_controller.py` script into a pip-installable module which contains (at the moment) only the `BaseSubmissionController`.

I've moved the `AdditionTableSubmissionController` example to the `examples/` directory and added a `PwBaseSubmissionController` example, which will need some more generalization in the future if kept.

I also added a simple pre-commit configuration, yapf style, and `pyproject.toml` based on other AiiDA projects (`aiida-quantumespresso` and `aiida-core`).